### PR TITLE
fix: Optimize sigma points generation in Unscented Kalman filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ file(GLOB state_vector_views_SRC src/state_vector_views/*)
 file(GLOB measurement_vector_views_SRC src/measurement_vector_views/*)
 file(GLOB beliefs_SRC src/beliefs/*)
 
-add_executable(sensor_fusion
+set(SRC_EXCEPT_MAIN
         ${sensors_SRC}
         ${states_SRC}
         ${process_models_SRC}
@@ -34,10 +34,18 @@ add_executable(sensor_fusion
         ${beliefs_SRC}
         ${state_vector_views_SRC}
         ${measurement_vector_views_SRC}
-        src/main.cpp
 )
 
-target_link_libraries(sensor_fusion z ssl uv uWS)
+add_executable(sensor_fusion_udacity_sim
+        ${SRC_EXCEPT_MAIN}
+        src/mains/udacity_sim_main.cpp
+)
+target_link_libraries(sensor_fusion_udacity_sim z ssl uv uWS)
+
+add_executable(sensor_fusion_all
+        ${SRC_EXCEPT_MAIN}
+        src/mains/all_main.cpp
+)
 
 add_library(Catch INTERFACE)
 add_executable( sensor_fusion_test

--- a/include/fusion.hpp
+++ b/include/fusion.hpp
@@ -20,6 +20,8 @@
 #ifndef SENSOR_FUSION_FUSION_HEADER_HPP
 #define SENSOR_FUSION_FUSION_HEADER_HPP
 
+
+#include "definitions.hpp"
 #include "filters.hpp"
 #include "process_models.hpp"
 #include "measurement_models.hpp"

--- a/src/filters/KalmanFilter.hpp
+++ b/src/filters/KalmanFilter.hpp
@@ -105,7 +105,7 @@ namespace ser94mor
        * Predicts the object's state in dt time in the future in accordance with the process model
        * and input control vector and then incorporates the sensor measurement into the belief.
        *
-       * Notice that process model and mesurement model can be either linear and non-linear.
+       * Notice that process model and measurement model can be either linear and non-linear.
        *
        * @param bel a current belief of the object's state
        * @param ut a control vector

--- a/src/mains/all_main.cpp
+++ b/src/mains/all_main.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2018-2019  Sergey Morozov <sergey@morozov.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <fusion.hpp>
+
+#include <cstdlib>
+
+using namespace ser94mor::sensor_fusion;
+
+int main(int, char**)
+{
+  // parameter initialization
+  CV::ProcessNoiseCovarianceMatrix cv_mtx;
+  cv_mtx << 1.0, 2.0,
+            3.0, 4.0;
+  
+  CTRV::ProcessNoiseCovarianceMatrix ctrv_mtx;
+  ctrv_mtx << 5.0, 6.0,
+              7.0, 8.0;
+
+  Lidar::MeasurementCovarianceMatrix lidar_mtx;
+  lidar_mtx <<  9.0, 10.0,
+               11.0, 12.0;
+
+  Radar::MeasurementCovarianceMatrix radar_mtx;
+  radar_mtx << 13.0, 14.0, 15.0,
+               16.0, 17.0, 18.0,
+               19.0, 20.0, 21.0;
+  
+  Lidar::Measurement lidar_measurement{22.0, Lidar::MeasurementVector::Constant(23.0)};
+  
+  Radar::Measurement radar_measurement{24.0, Radar::MeasurementVector::Constant(25.0)};
+  
+  // variations of Kalman filter
+  KF_CV_LIDAR_Fusion kf_cv_lidar_fusion{cv_mtx, lidar_mtx};
+  kf_cv_lidar_fusion.ProcessMeasurement(lidar_measurement);
+  kf_cv_lidar_fusion.ProcessMeasurement(radar_measurement); 
+  
+  EKF_CV_RADAR_Fusion ekf_cv_radar_fusion{cv_mtx, radar_mtx};
+  ekf_cv_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ekf_cv_radar_fusion.ProcessMeasurement(radar_measurement);
+  
+  EKF_CV_LIDAR_RADAR_Fusion ekf_cv_lidar_radar_fusion{cv_mtx, lidar_mtx, radar_mtx};
+  ekf_cv_lidar_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ekf_cv_lidar_radar_fusion.ProcessMeasurement(radar_measurement);
+  
+  EKF_CTRV_LIDAR_Fusion ekf_ctrv_lidar_fusion{ctrv_mtx, lidar_mtx};
+  ekf_ctrv_lidar_fusion.ProcessMeasurement(lidar_measurement);
+  ekf_ctrv_lidar_fusion.ProcessMeasurement(radar_measurement);
+  
+  EKF_CTRV_RADAR_Fusion ekf_ctrv_radar_fusion{ctrv_mtx, radar_mtx};
+  ekf_ctrv_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ekf_ctrv_radar_fusion.ProcessMeasurement(radar_measurement);
+  
+  EKF_CTRV_LIDAR_RADAR_Fusion ekf_ctrv_lidar_radar_fusion{ctrv_mtx, lidar_mtx, radar_mtx};
+  ekf_ctrv_lidar_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ekf_ctrv_lidar_radar_fusion.ProcessMeasurement(radar_measurement);
+
+  UKF_CV_RADAR_Fusion ukf_cv_radar_fusion{cv_mtx, radar_mtx};
+  ukf_cv_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ukf_cv_radar_fusion.ProcessMeasurement(radar_measurement);
+  
+  UKF_CV_LIDAR_RADAR_Fusion ukf_cv_lidar_radar_fusion{cv_mtx, lidar_mtx, radar_mtx};
+  ukf_cv_lidar_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ukf_cv_lidar_radar_fusion.ProcessMeasurement(radar_measurement);
+  
+  UKF_CTRV_LIDAR_Fusion ukf_ctrv_lidar_fusion{ctrv_mtx, lidar_mtx};
+  ukf_ctrv_lidar_fusion.ProcessMeasurement(lidar_measurement);
+  ukf_ctrv_lidar_fusion.ProcessMeasurement(radar_measurement);
+  
+  UKF_CTRV_RADAR_Fusion ukf_ctrv_radar_fusion{ctrv_mtx, radar_mtx};
+  ukf_ctrv_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ukf_ctrv_radar_fusion.ProcessMeasurement(radar_measurement);
+  
+  UKF_CTRV_LIDAR_RADAR_Fusion ukf_ctrv_lidar_radar_fusion{ctrv_mtx, lidar_mtx, radar_mtx};
+  ukf_ctrv_lidar_radar_fusion.ProcessMeasurement(lidar_measurement);
+  ukf_ctrv_lidar_radar_fusion.ProcessMeasurement(radar_measurement);
+  
+  return EXIT_SUCCESS;
+}

--- a/src/mains/udacity_sim_main.cpp
+++ b/src/mains/udacity_sim_main.cpp
@@ -115,24 +115,24 @@ int main(int, char* argv[])
 {
   openlog(argv[0], LOG_PID, LOG_USER);
 
-  CTRV::ProcessNoiseCovarianceMatrix cv_p_mtx;
-  cv_p_mtx << 9.0, 0.0,
-              0.0, 9.0;
+  CV::ProcessNoiseCovarianceMatrix cv_mtx;
+  cv_mtx << 9.0, 0.0,
+            0.0, 9.0;
 
-  CTRV::ProcessNoiseCovarianceMatrix ctrv_p_mtx;
-  ctrv_p_mtx << 0.126025,  0.0,
-                     0.0, 0.16;
+  CTRV::ProcessNoiseCovarianceMatrix ctrv_mtx;
+  ctrv_mtx << 0.126025,  0.0,
+              0.0,      0.16;
 
   Lidar::MeasurementCovarianceMatrix lidar_mtx;
   lidar_mtx << 0.0225,    0.0,
-                  0.0, 0.0225;
+               0.0, 0.0225;
   
   Radar::MeasurementCovarianceMatrix radar_mtx;
   radar_mtx << 0.09,    0.0,  0.0,
                 0.0, 0.0009,  0.0,
                 0.0,    0.0, 0.09;
 
-  UKF_CTRV_LIDAR_RADAR_Fusion fusion{ctrv_p_mtx, lidar_mtx, radar_mtx};
+  UKF_CTRV_LIDAR_RADAR_Fusion fusion{ctrv_mtx, lidar_mtx, radar_mtx};
 
   uWS::Hub h;
 

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -20,11 +20,26 @@
 
 #include <cmath>
 
-void Utils::NormalizeAngle(double_t* angle)
+
+namespace ser94mor
 {
-  auto times = std::round( std::fabs( *angle / (2.0 * M_PI) ) );  // for the case when angle is very very large
+  namespace sensor_fusion
+  {
 
-  if (*angle >  M_PI) *angle -= times * 2.0 * M_PI;
+    void Utils::NormalizeAngle(double_t* angle)
+    {
+      const auto times = std::round(std::fabs(*angle / (2. * M_PI)));  // for the case when angle is very very large
 
-  if (*angle < -M_PI) *angle += times * 2.0 * M_PI;
+      if (*angle > M_PI)
+      {
+        *angle -= times * 2.0 * M_PI;
+      }
+
+      if (*angle < -M_PI)
+      {
+        *angle += times * 2.0 * M_PI;
+      }
+    }
+
+  }
 }

--- a/src/utils/Utils.hpp
+++ b/src/utils/Utils.hpp
@@ -22,20 +22,28 @@
 #include <cmath>
 
 
-/**
- * Class containing different helper methods.
- */
-class Utils
+namespace ser94mor
 {
-public:
+  namespace sensor_fusion
+  {
 
-  /**
-   * Normalize angle to be between [-pi, pi].
-   * @param angle the pointer to variable containing angle to be normalized.
-   */
-  static void NormalizeAngle(double_t* angle);
+    /**
+     * Class containing different helper methods.
+     */
+    class Utils
+    {
+    public:
 
-};
+      /**
+       * Normalize angle to be between [-pi, pi].
+       * @param angle the pointer to variable containing angle to be normalized.
+       */
+      static void NormalizeAngle(double_t* angle);
+
+    };
+
+  }
+}
 
 
 #endif //SENSOR_FUSION_UTILS_HPP


### PR DESCRIPTION
Re-use previously generated sigma points from prediction step in update step when possible, that is, when both process and measurement model are non-linear.

Resolves: #17